### PR TITLE
fix: build target never exit

### DIFF
--- a/packages/nx-bun/src/executors/build/executor.ts
+++ b/packages/nx-bun/src/executors/build/executor.ts
@@ -120,11 +120,13 @@ export default async function* bundleExecutor(
         runningBun.exited.then((code) => {
           console.log(`Build completed for  ${context.projectName}`);
           next({ success: code === 0 });
+          done();
         });
       } else {
         runningBun.on('exit', (code) => {
           console.log(`Build completed for  ${context.projectName}`);
           next({ success: code === 0 });
+          done();
         });
       }
     });


### PR DESCRIPTION
Resolves issue #21 

I've add explicit `done()` call if executor is not running into Bun environment (globalThis.Bun === undefined)